### PR TITLE
Remove channel ID as scheduled loop removed

### DIFF
--- a/example.env
+++ b/example.env
@@ -1,2 +1,1 @@
 TOKEN=
-CHANNEL_ID=


### PR DESCRIPTION
Channel ID was used for sending scheduled messages to a channel of your choice. This has been removed so this ID is unused. Removing this from the example `.env` file to help setup in the future.